### PR TITLE
Bump release to 0.9.1 for migrations fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.9.1]
-### Added
+### Fixed
 - fixed migrations
 
 ## [0.9.0]

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.9.1]
+### Added
+- fixed migrations
+
 ## [0.9.0]
 ### Changed
 - added support for stripe 2.X and dropped support for 1.X

--- a/aa_stripe/__init__.py
+++ b/aa_stripe/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Ro Stripe"
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __author__ = "Remigiusz Dymecki"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019 Ro"


### PR DESCRIPTION
This updates the release tags in this repo in preparation for a 0.9.1 release.

I plan on tagging a github release once this merges for 0.9.1 and also pushing a new pypi package as well.