### PR TITLE
Adding ProdSec consolidated workflow files

### DIFF
--- a/.github/workflows/Prodsec_Workflow.yml
+++ b/.github/workflows/Prodsec_Workflow.yml
@@ -1,0 +1,33 @@
+# Product Security tooling
+# Runs Manifest SBOM generation, CodeQL Scanning, and Dependency Check Scanning
+---
+name: Product Security Tooling
+
+'on':
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  sbom_generator:
+    uses: HealthByRo/ro-github-actions/.github/workflows/manifest_sbom.yml@main
+    with:
+      languages: '["Python"]'
+    secrets:
+      ssh_key: ${{ secrets.SSH_RO_CI_DEPLOY }}
+      manifest_key: ${{ secrets.MANIFEST_SBOM }}
+
+  dependency-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Dependency Check
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: critical
+          license-check: false
+        continue-on-error: true


### PR DESCRIPTION
Creating a consolidated workflow file for ProdSec tooling, this will run Dependabot and Manifest on PR and release creation.

 Ticket: https://ro-engine.atlassian.net/browse/PRODSEC-550