### PR TITLE
ECP-2415 -- add extra details to charge request

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+##[0.13.0]
+### Added
+- optional metadata field for member identitifer `member_uuid`
+- optional metadata field for payment identifier `payment_uuid`
+
+
 ##[0.12.0]
 ### Removed
 - Removed support for Python <3.9

--- a/aa_stripe/__init__.py
+++ b/aa_stripe/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Ro Stripe"
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 __author__ = "Remigiusz Dymecki"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019 Ro"

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -409,9 +409,11 @@ class StripeCharge(StripeBasicModel):
             metadata = {
                 "object_id": self.object_id,
                 "content_type_id": self.content_type_id,
-                "member_uuid": str(self.user.uuid),
-                "origin": "roman_api",
             }
+            if settings.PAYMENT_ORIGIN:
+                metadata["origin"] = settings.PAYMENT_ORIGIN
+            if hasattr(self.user, "uuid"):
+                metadata["member_uuid"] = str(self.user.uuid)
             if payment_uuid:
                 metadata["payment_uuid"] = str(payment_uuid)
 

--- a/aa_stripe/models.py
+++ b/aa_stripe/models.py
@@ -410,7 +410,7 @@ class StripeCharge(StripeBasicModel):
                 "object_id": self.object_id,
                 "content_type_id": self.content_type_id,
                 "member_uuid": str(self.user.uuid),
-                "custody": "roman_api",
+                "origin": "roman_api",
             }
             if payment_uuid:
                 metadata["payment_uuid"] = str(payment_uuid)

--- a/aa_stripe/settings.py
+++ b/aa_stripe/settings.py
@@ -11,6 +11,7 @@ and the settings can be accessed by the aa_stripe.settings.stripe_settings objec
 from aa_stripe.settings import stripe_settings
 stripe_settings.API_KEY  # "api_key"
 """
+
 from __future__ import unicode_literals
 
 from django.conf import settings
@@ -20,8 +21,12 @@ DEFAULTS = {
     "PENDING_WEBHOOKS_THRESHOLD": 20,
     "API_KEY": "",
     "WEBHOOK_ENDPOINT_SECRET": "",
-    "USER_MODEL": settings.AUTH_USER_MODEL
+    "USER_MODEL": settings.AUTH_USER_MODEL,
 }
+
+PAYMENT_ORIGIN = (
+    settings.PAYMENT_ORIGIN if hasattr(settings, "PAYMENT_ORIGIN") else None
+)
 
 
 class StripeSettings(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def pytest_configure():
             "tests",
         ),
         AUTH_USER_MODEL="tests.TestUser",
+        PAYMENT_ORIGIN="test-roman_api",
         ROOT_URLCONF="aa_stripe.api_urls",
         TESTING=True,
         ENV_PREFIX="test-env",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,13 @@ def pytest_configure():
             "django.contrib.admin",
             "django.contrib.sites",
             "rest_framework",
-            "aa_stripe"
+            "aa_stripe",
+            "tests",
         ),
+        AUTH_USER_MODEL="tests.TestUser",
         ROOT_URLCONF="aa_stripe.api_urls",
         TESTING=True,
-
         ENV_PREFIX="test-env",
         STRIPE_SETTINGS_API_KEY="apikey",
-        STRIPE_SETTINGS_WEBHOOK_ENDPOINT_SECRET="fake"
+        STRIPE_SETTINGS_WEBHOOK_ENDPOINT_SECRET="fake",
     )

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,8 @@
+import uuid
+
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+
+class TestUser(AbstractUser):
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -1,9 +1,11 @@
 """Test charging users through the StripeCharge model"""
+
 import sys
 from io import StringIO
 
 import mock
 import stripe
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import TestCase
@@ -144,7 +146,7 @@ class TestCharges(TestCase):
             metadata={
                 "object_id": self.charge.object_id,
                 "content_type_id": self.charge.content_type_id,
-                "origin": "roman_api",
+                "origin": settings.PAYMENT_ORIGIN,
                 "member_uuid": str(self.user.uuid),
             },
         )

--- a/tests/test_charge.py
+++ b/tests/test_charge.py
@@ -144,6 +144,8 @@ class TestCharges(TestCase):
             metadata={
                 "object_id": self.charge.object_id,
                 "content_type_id": self.charge.content_type_id,
+                "origin": "roman_api",
+                "member_uuid": str(self.user.uuid),
             },
         )
 


### PR DESCRIPTION
WHAT:
- https://ro-engine.atlassian.net/browse/ECP-2415
- adds payment identifier and member identifier to charge metatada in stripe